### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   sonarqube:
     name: SonarQube


### PR DESCRIPTION
Potential fix for [https://github.com/AshuApurva14/python-webapp/security/code-scanning/2](https://github.com/AshuApurva14/python-webapp/security/code-scanning/2)

To fix this problem, we must add a `permissions` key at the appropriate scope in the workflow file. The minimal safe option is to add `permissions: contents: read` either at the top level (applying to all jobs), or under the `sonarqube` job (if additional jobs with other needs might be added later). For now, the simplest fix is to add at the workflow level, right before `jobs:`, since all current jobs only require read access. Edit `.github/workflows/code_analysis.yml` to insert:

```yaml
permissions:
  contents: read
```

between the workflow name/trigger and the jobs block. No imports or external changes are needed beyond this addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
